### PR TITLE
Bug/dev 104 web3 instance singleton

### DIFF
--- a/django_eth_events/event_listener.py
+++ b/django_eth_events/event_listener.py
@@ -26,10 +26,10 @@ class UnknownTransaction(Exception):
 
 class EventListener(Singleton):
 
-    def __init__(self, contract_map=None):
+    def __init__(self, contract_map=None, provider=None):
         super(EventListener, self).__init__()
         self.decoder = Decoder()  # Decodes Ethereum logs
-        self.web3 = Web3Service().web3  # Gets transaction and block info from ethereum
+        self.web3 = Web3Service(provider=provider).web3  # Gets transaction and block info from ethereum
 
         if not contract_map:
             contract_map = settings.ETH_EVENTS

--- a/django_eth_events/tests/test_singleton.py
+++ b/django_eth_events/tests/test_singleton.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from django.test import TestCase
+from web3 import RPCProvider, IPCProvider
+from django_eth_events.web3_service import Web3Service
+
+
+
+class TestSingleton(TestCase):
+
+    def test_single_istance(self):
+        service1 = Web3Service()
+        service2 = Web3Service()
+        self.assertEquals(service1.web3, service2.web3)
+
+    def test_arg_rpc_provider(self):
+        rpc_provider = RPCProvider(
+            host='localhost',
+            port=8545,
+            ssl=0
+        )
+
+        service1 = Web3Service()
+        service2 = Web3Service(rpc_provider)
+        self.assertEquals(service1.web3, service2.web3)
+
+    def test_arg_ipc_provider(self):
+        ipc_provider = IPCProvider(
+            ipc_path='',
+            testnet=True
+        )
+
+        service1 = Web3Service()
+        self.assertIsInstance(service1.web3.currentProvider, RPCProvider)
+        service2 = Web3Service(ipc_provider)
+        self.assertIsInstance(service2.web3.currentProvider, IPCProvider)
+        self.assertEquals(service2.web3.currentProvider, ipc_provider)

--- a/django_eth_events/web3_service.py
+++ b/django_eth_events/web3_service.py
@@ -15,7 +15,7 @@ class Web3Service(object):
 
         def __init__(self, provider=None):
             if not provider:
-                provider = RPCProvider(
+                provider = self.default_provider(
                     host=settings.ETHEREUM_NODE_HOST,
                     port=settings.ETHEREUM_NODE_PORT,
                     ssl=settings.ETHEREUM_NODE_SSL

--- a/django_eth_events/web3_service.py
+++ b/django_eth_events/web3_service.py
@@ -1,18 +1,36 @@
 from django.conf import settings
 from web3 import Web3, RPCProvider
 
-from .singleton import Singleton
 
+class Web3Service(object):
+    """
+    Singleton Web3 object manager, returns a new object if
+    the argument provider is different than the current used provider.
+    """
+    instance = None
 
-class Web3Service(Singleton):
-    def __init__(
-            self,
-            rpc_provider=None):
-        if not rpc_provider:
-            rpc_provider = RPCProvider(
-                host=settings.ETHEREUM_NODE_HOST,
-                port=settings.ETHEREUM_NODE_PORT,
-                ssl=settings.ETHEREUM_NODE_SSL
-            )
-        super(Web3Service, self).__init__()
-        self.web3 = Web3(rpc_provider)
+    class __Web3Service:
+        web3 = None
+        default_provider = RPCProvider
+
+        def __init__(self, provider=None):
+            if not provider:
+                provider = RPCProvider(
+                    host=settings.ETHEREUM_NODE_HOST,
+                    port=settings.ETHEREUM_NODE_PORT,
+                    ssl=settings.ETHEREUM_NODE_SSL
+                )
+
+            self.web3 = Web3(provider)
+
+    def __new__(cls, provider=None):
+        if not Web3Service.instance:
+            Web3Service.instance = Web3Service.__Web3Service(provider)
+        elif provider and not isinstance(provider, Web3Service.instance.web3.currentProvider.__class__):
+            Web3Service.instance = Web3Service.__Web3Service(provider)
+        elif not provider and not isinstance(Web3Service.instance.web3.currentProvider, Web3Service.instance.default_provider):
+            Web3Service.instance = Web3Service.__Web3Service(provider)
+        return Web3Service.instance
+
+    def __getattr__(self, item):
+        return getattr(self.instance, item)


### PR DESCRIPTION
BEFORE:
Web3Service singleton wasn't working as expected, no real singleton on web3 property.

AFTER:
Singleton is able now to maintain a single web3 property instance as long as the software is running and is also able to instantiate other providers than RPCPRovider.
