### PR TITLE
Bug/dev 109 check reorg provider

### DIFF
--- a/django_eth_events/reorgs.py
+++ b/django_eth_events/reorgs.py
@@ -20,12 +20,20 @@ class NoBackup(Exception):
         self.errors = errors
 
 
-def check_reorg():
+def check_reorg(provider=None):
+    """
+    Checks for reorgs to happening
+    :param provider: optional Web3 provider instance
+    :return: Tuple (True|False, None|Block number)
+    :raise NetworkReorgException
+    :raise UnknownBlockReorg
+    :raise NoBackup
+    """
     web3 = None
     saved_block_number = Daemon.get_solo().block_number
 
     try:
-        web3 = Web3Service().web3
+        web3 = Web3Service(provider=provider).web3
         if web3.isConnected():
             current_block_number = web3.eth.blockNumber
         else:

--- a/django_eth_events/tests/test_celery.py
+++ b/django_eth_events/tests/test_celery.py
@@ -6,7 +6,7 @@ from django_eth_events.factories import DaemonFactory
 from django_eth_events.models import Daemon, Block
 from django_eth_events.tasks import event_listener
 from django_eth_events.web3_service import Web3Service
-from django_eth_events.tests.codes import centralized_oracle_abi, centralized_oracle_bytecode
+from django_eth_events.tests.utils import centralized_oracle_abi, centralized_oracle_bytecode
 from django_eth_events.chainevents import AbstractEventReceiver
 from django.conf import settings
 from web3 import TestRPCProvider

--- a/django_eth_events/tests/test_event_listener_exec.py
+++ b/django_eth_events/tests/test_event_listener_exec.py
@@ -5,31 +5,19 @@ from django.test import TestCase
 from django_eth_events.factories import DaemonFactory
 from django_eth_events.event_listener import EventListener
 from django_eth_events.web3_service import Web3Service
-from django_eth_events.chainevents import AbstractEventReceiver
 from django_eth_events.models import Daemon, Block
+from django_eth_events.tests.codes import CentralizedOracle
 from web3 import TestRPCProvider
 from json import loads
 from django_eth_events.tests.codes import centralized_oracle_abi, centralized_oracle_bytecode
 from django_eth_events.utils import remove_0x_head
 
 
-centralized_oracles = []
-
-
-class CentralizedOraclesReceiver(AbstractEventReceiver):
-    def save(self, decoded_event, block_info):
-        centralized_oracles.append(decoded_event)
-        return decoded_event
-
-    def rollback(self, decoded_event, block_info):
-        centralized_oracles.pop()
-
-
 class TestDaemonExec(TestCase):
     def setUp(self):
         os.environ.update({'TESTRPC_GAS_LIMIT': '10000000000'})
-        self.rpc = TestRPCProvider()
-        web3_service = Web3Service(self.rpc)
+        self.provider = TestRPCProvider()
+        web3_service = Web3Service(self.provider)
         self.web3 = web3_service.web3
         # Mock web3
         self.daemon = DaemonFactory()
@@ -46,22 +34,20 @@ class TestDaemonExec(TestCase):
             {
                 'NAME': 'Centralized Oracle Factory',
                 'EVENT_ABI': centralized_oracle_abi,
-                'EVENT_DATA_RECEIVER': 'django_eth_events.tests.test_event_listener_exec.CentralizedOraclesReceiver',
+                'EVENT_DATA_RECEIVER': 'django_eth_events.tests.codes.CentralizedOraclesReceiver',
                 'ADDRESSES': [self.centralized_oracle_factory_address[2::]]
             }
         ]
-
-        self.listener_under_test = EventListener(self.contracts)
+        self.listener_under_test = EventListener(contract_map=self.contracts, provider=self.provider)
+        CentralizedOracle().reset()
 
     def tearDown(self):
-        self.rpc.server.shutdown()
-        self.rpc.server.server_close()
-        self.rpc = None
-        global centralized_oracles
-        centralized_oracles = []
+        self.provider.server.shutdown()
+        self.provider.server.server_close()
+        self.provider = None
 
     def test_create_centralized_oracle(self):
-        self.assertEqual(len(centralized_oracles), 0)
+        self.assertEqual(CentralizedOracle().len(), 0)
         self.assertEqual(0, Daemon.get_solo().block_number)
         self.assertEqual(0, Block.objects.all().count())
 
@@ -69,7 +55,7 @@ class TestDaemonExec(TestCase):
         tx_hash = self.centralized_oracle_factory.transact(self.tx_data).createCentralizedOracle('QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
         self.assertIsNotNone(tx_hash)
         self.listener_under_test.execute()
-        self.assertEqual(len(centralized_oracles), 1)
+        self.assertEqual(CentralizedOracle().len(), 1)
         self.assertEqual(1, Daemon.get_solo().block_number)
 
         # Check backup
@@ -82,7 +68,7 @@ class TestDaemonExec(TestCase):
         accounts = self.web3.eth.accounts
         self.web3.eth.sendTransaction({'from': accounts[0], 'to': accounts[1], 'value': 5000000})
         self.assertEqual(0, Block.objects.all().count())
-        self.assertEqual(len(centralized_oracles), 0)
+        self.assertEqual(CentralizedOracle().len(), 0)
         self.assertEqual(1, self.web3.eth.blockNumber)
 
         # Create centralized oracle
@@ -90,16 +76,16 @@ class TestDaemonExec(TestCase):
             'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
         self.assertIsNotNone(tx_hash)
         self.listener_under_test.execute()
-        self.assertEqual(len(centralized_oracles), 1)
+        self.assertEqual(CentralizedOracle().len(), 1)
         self.assertEqual(2, Daemon.get_solo().block_number)
         self.assertEqual(2, Block.objects.all().count())
         self.assertEqual(2, self.web3.eth.blockNumber)
 
         # Reset blockchain (simulates reorg)
-        self.rpc.server.shutdown()
-        self.rpc.server.server_close()
-        self.rpc = TestRPCProvider()
-        web3_service = Web3Service(self.rpc)
+        self.provider.server.shutdown()
+        self.provider.server.server_close()
+        self.provider = TestRPCProvider()
+        web3_service = Web3Service(self.provider)
         self.web3 = web3_service.web3
         self.assertEqual(0, self.web3.eth.blockNumber)
 
@@ -113,6 +99,6 @@ class TestDaemonExec(TestCase):
         Block.objects.filter(block_number=1).update(block_hash=block_hash)
 
         self.listener_under_test.execute()
-        self.assertEqual(len(centralized_oracles), 0)
+        self.assertEqual(CentralizedOracle().len(), 0)
         self.assertEqual(2, Daemon.get_solo().block_number)
         self.assertEqual(2, Block.objects.all().count())

--- a/django_eth_events/tests/test_event_listener_exec.py
+++ b/django_eth_events/tests/test_event_listener_exec.py
@@ -6,10 +6,10 @@ from django_eth_events.factories import DaemonFactory
 from django_eth_events.event_listener import EventListener
 from django_eth_events.web3_service import Web3Service
 from django_eth_events.models import Daemon, Block
-from django_eth_events.tests.codes import CentralizedOracle
+from django_eth_events.tests.utils import CentralizedOracle
 from web3 import TestRPCProvider
 from json import loads
-from django_eth_events.tests.codes import centralized_oracle_abi, centralized_oracle_bytecode
+from django_eth_events.tests.utils import centralized_oracle_abi, centralized_oracle_bytecode
 from django_eth_events.utils import remove_0x_head
 
 
@@ -34,7 +34,7 @@ class TestDaemonExec(TestCase):
             {
                 'NAME': 'Centralized Oracle Factory',
                 'EVENT_ABI': centralized_oracle_abi,
-                'EVENT_DATA_RECEIVER': 'django_eth_events.tests.codes.CentralizedOraclesReceiver',
+                'EVENT_DATA_RECEIVER': 'django_eth_events.tests.utils.CentralizedOraclesReceiver',
                 'ADDRESSES': [self.centralized_oracle_factory_address[2::]]
             }
         ]
@@ -47,7 +47,7 @@ class TestDaemonExec(TestCase):
         self.provider = None
 
     def test_create_centralized_oracle(self):
-        self.assertEqual(CentralizedOracle().len(), 0)
+        self.assertEqual(CentralizedOracle().length(), 0)
         self.assertEqual(0, Daemon.get_solo().block_number)
         self.assertEqual(0, Block.objects.all().count())
 
@@ -55,7 +55,7 @@ class TestDaemonExec(TestCase):
         tx_hash = self.centralized_oracle_factory.transact(self.tx_data).createCentralizedOracle('QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
         self.assertIsNotNone(tx_hash)
         self.listener_under_test.execute()
-        self.assertEqual(CentralizedOracle().len(), 1)
+        self.assertEqual(CentralizedOracle().length(), 1)
         self.assertEqual(1, Daemon.get_solo().block_number)
 
         # Check backup
@@ -68,7 +68,7 @@ class TestDaemonExec(TestCase):
         accounts = self.web3.eth.accounts
         self.web3.eth.sendTransaction({'from': accounts[0], 'to': accounts[1], 'value': 5000000})
         self.assertEqual(0, Block.objects.all().count())
-        self.assertEqual(CentralizedOracle().len(), 0)
+        self.assertEqual(CentralizedOracle().length(), 0)
         self.assertEqual(1, self.web3.eth.blockNumber)
 
         # Create centralized oracle
@@ -76,7 +76,7 @@ class TestDaemonExec(TestCase):
             'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
         self.assertIsNotNone(tx_hash)
         self.listener_under_test.execute()
-        self.assertEqual(CentralizedOracle().len(), 1)
+        self.assertEqual(CentralizedOracle().length(), 1)
         self.assertEqual(2, Daemon.get_solo().block_number)
         self.assertEqual(2, Block.objects.all().count())
         self.assertEqual(2, self.web3.eth.blockNumber)
@@ -99,6 +99,6 @@ class TestDaemonExec(TestCase):
         Block.objects.filter(block_number=1).update(block_hash=block_hash)
 
         self.listener_under_test.execute()
-        self.assertEqual(CentralizedOracle().len(), 0)
+        self.assertEqual(CentralizedOracle().length(), 0)
         self.assertEqual(2, Daemon.get_solo().block_number)
         self.assertEqual(2, Block.objects.all().count())

--- a/django_eth_events/tests/test_event_listener_functions.py
+++ b/django_eth_events/tests/test_event_listener_functions.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from django_eth_events.factories import DaemonFactory
 from django_eth_events.event_listener import EventListener
 from django_eth_events.utils import normalize_address_without_0x
-from django_eth_events.tests.codes import abi, bin_hex
+from django_eth_events.tests.utils import abi, bin_hex
 
 
 class TestDaemon(TestCase):

--- a/django_eth_events/tests/test_singleton.py
+++ b/django_eth_events/tests/test_singleton.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.test import TestCase
 from web3 import RPCProvider, IPCProvider
 from django_eth_events.web3_service import Web3Service
-
+from django_eth_events.event_listener import EventListener
 
 
 class TestSingleton(TestCase):
@@ -35,3 +35,15 @@ class TestSingleton(TestCase):
         service2 = Web3Service(ipc_provider)
         self.assertIsInstance(service2.web3.currentProvider, IPCProvider)
         self.assertEquals(service2.web3.currentProvider, ipc_provider)
+
+    def test_event_listener_singleton(self):
+        ipc_provider = IPCProvider(
+            ipc_path='',
+            testnet=True
+        )
+
+        listener1 = EventListener()
+        listener2 = EventListener()
+        self.assertEquals(listener1, listener2)
+        listener3 = EventListener(provider=ipc_provider)
+        self.assertNotEquals(listener2, listener3)

--- a/django_eth_events/tests/utils.py
+++ b/django_eth_events/tests/utils.py
@@ -221,7 +221,7 @@ class CentralizedOracle(object):
         def pop(self):
             self.oracles.pop()
 
-        def len(self):
+        def length(self):
             return len(self.oracles)
 
         def reset(self):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
 
 setup(
     name='django-eth-events',
-    version='1.0.32',
+    version='1.0.33',
     packages=find_packages(),
     include_package_data=True,
     install_requires=requirements,


### PR DESCRIPTION
BEFORE:
check_reorgs and EventListener didn't allow to use more providers than RPCProvider.

AFTER:
check_reorgs and EventListener accept an optional provider instance in input. Improved some test cases.