### PR TITLE
Remove Python2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
 dist: trusty
 env:

--- a/README.md
+++ b/README.md
@@ -58,5 +58,6 @@ python django_eth_events/manage.py test
 
 Coverage can be run using _coverage_ tool:
 ```
+pip install coverage
 coverage run --source=django_eth_events django_eth_events/manage.py test
 ```

--- a/django_eth_events/__init__.py
+++ b/django_eth_events/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .apps import app as celery_app
 default_app_config = 'django_eth_events.apps.EtherLogsConfig'
 __all__ = ['celery_app']

--- a/django_eth_events/admin.py
+++ b/django_eth_events/admin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from django.contrib import admin
 from solo.admin import SingletonModelAdmin
+
 from . import models
 
 

--- a/django_eth_events/apps.py
+++ b/django_eth_events/apps.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from django.apps import AppConfig
 from django.conf import settings
 from celery import Celery

--- a/django_eth_events/chainevents.py
+++ b/django_eth_events/chainevents.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+
 from .singleton import SingletonABCMeta
 
 

--- a/django_eth_events/factories.py
+++ b/django_eth_events/factories.py
@@ -1,10 +1,11 @@
 import factory
-from django_eth_events import models
+
+from .models import Daemon
 
 
 class DaemonFactory(factory.DjangoModelFactory):
 
     class Meta:
-        model = models.Daemon
+        model = Daemon
 
     block_number = 0

--- a/django_eth_events/manage.py
+++ b/django_eth_events/manage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
+import importlib
 import os
 import sys
-import importlib
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.base")

--- a/django_eth_events/management/commands/resync_daemon.py
+++ b/django_eth_events/management/commands/resync_daemon.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
-from django_eth_events.models import Daemon, Block
+
+from ...models import Daemon, Block
 
 
 class Command(BaseCommand):

--- a/django_eth_events/models.py
+++ b/django_eth_events/models.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.db import models
 from model_utils.models import TimeStampedModel
 from solo.models import SingletonModel

--- a/django_eth_events/reorgs.py
+++ b/django_eth_events/reorgs.py
@@ -1,6 +1,6 @@
-from django_eth_events.models import Daemon, Block
-from django_eth_events.web3_service import Web3Service
-from django_eth_events.utils import remove_0x_head
+from .models import Daemon, Block
+from .utils import remove_0x_head
+from .web3_service import Web3Service
 
 
 class NetworkReorgException(Exception):
@@ -29,15 +29,15 @@ def check_reorg(provider=None):
     :raise UnknownBlockReorg
     :raise NoBackup
     """
-    web3 = None
     saved_block_number = Daemon.get_solo().block_number
 
+    web3 = None
     try:
         web3 = Web3Service(provider=provider).web3
         if web3.isConnected():
             current_block_number = web3.eth.blockNumber
         else:
-            raise Exception()
+            raise Exception('Web3 provider is not connected')
     except:
         raise NetworkReorgException('Unable to get block number from current node. Check the node is up and running.')
 

--- a/django_eth_events/tests/mocked_testrpc_reorg.py
+++ b/django_eth_events/tests/mocked_testrpc_reorg.py
@@ -1,6 +1,7 @@
+from http.server import BaseHTTPRequestHandler
 from json import dumps, loads
+
 from django.core.cache import cache
-from six.moves.BaseHTTPServer import BaseHTTPRequestHandler
 
 
 class MockedTestrpc(BaseHTTPRequestHandler):

--- a/django_eth_events/tests/test_celery.py
+++ b/django_eth_events/tests/test_celery.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from django.test import TestCase
-from django_eth_events.tasks import deadlock_checker
-from django_eth_events.factories import DaemonFactory
-from django_eth_events.models import Daemon, Block
-from django_eth_events.tasks import event_listener
-from django_eth_events.web3_service import Web3Service
-from django_eth_events.tests.utils import centralized_oracle_abi, centralized_oracle_bytecode
-from django_eth_events.chainevents import AbstractEventReceiver
-from django.conf import settings
-from web3 import TestRPCProvider
-from time import sleep
 import os
+from time import sleep
+
+from django.test import TestCase
+from django.conf import settings
+
+from eth_tester import EthereumTester
+from web3.providers.eth_tester import EthereumTesterProvider
+
+from ..chainevents import AbstractEventReceiver
+from ..factories import DaemonFactory
+from ..models import Daemon, Block
+from ..tasks import deadlock_checker, event_listener
+from ..web3_service import Web3Service
+from .utils import centralized_oracle_abi, centralized_oracle_bytecode
 
 
 class DummyEventReceiver(AbstractEventReceiver):
@@ -26,42 +28,44 @@ class TestCelery(TestCase):
 
     def setUp(self):
         os.environ.update({'TESTRPC_GAS_LIMIT': '10000000000'})
-        self.rpc = TestRPCProvider()
-        self.web3 = Web3Service().web3
-        self.tx_data = {'from': self.web3.eth.accounts[0], 'gas': 1000000}
+        self.web3 = Web3Service(provider=EthereumTesterProvider(EthereumTester())).web3
+        self.provider = self.web3.providers[0]
+        self.web3.eth.defaultAccount = self.web3.eth.coinbase
+        self.tx_data = {'from': self.web3.eth.coinbase,
+                        'gas': 1000000}
         self.event_receivers = []
 
     def tearDown(self):
-        self.rpc.server.shutdown()
-        self.rpc.server.server_close()
-        self.rpc = None
-
         # Delete centralized oracles
+        self.provider.ethereum_tester.reset_to_genesis()
+        self.assertEqual(0, self.web3.eth.blockNumber)
 
     def test_deadlock_checker(self):
         daemon = DaemonFactory(listener_lock=True)
         # sleep process to simulate old Daemon instance
         sleep(2)
-        deadlock_checker(2000) # 2 seconds
+        deadlock_checker(2000)  # 2 seconds
         daemon_test = Daemon.get_solo()
         # Test deadlock detection
-        self.assertEquals(daemon_test.listener_lock, False)
+        self.assertEqual(daemon_test.listener_lock, False)
 
         daemon.listener_lock = True
         daemon.save()
         deadlock_checker()
         daemon_test = Daemon.get_solo()
-        self.assertEquals(daemon_test.listener_lock, True)
+        self.assertEqual(daemon_test.listener_lock, True)
 
     def test_event_listener(self):
         daemon_factory = DaemonFactory(listener_lock=False)
         # Number of blocks analyzed by Event Listener
         n_blocks = Block.objects.all().count()
         # Create centralized oracle factory contract
-        centralized_contract_factory = self.web3.eth.contract(abi=centralized_oracle_abi, bytecode=centralized_oracle_bytecode)
+        centralized_contract_factory = self.web3.eth.contract(abi=centralized_oracle_abi,
+                                                              bytecode=centralized_oracle_bytecode)
         tx_hash = centralized_contract_factory.deploy()
         centralized_oracle_factory_address = self.web3.eth.getTransactionReceipt(tx_hash).get('contractAddress')
-        centralized_oracle_factory = self.web3.eth.contract(centralized_oracle_factory_address, abi=centralized_oracle_abi)
+        centralized_oracle_factory = self.web3.eth.contract(centralized_oracle_factory_address,
+                                                            abi=centralized_oracle_abi)
 
         # Event receiver
         centralized_event_receiver = {
@@ -75,13 +79,13 @@ class TestCelery(TestCase):
         setattr(settings, 'ETH_EVENTS', self.event_receivers)
 
         # Start Celery Task
-        event_listener()
+        event_listener(self.provider)
         # Create centralized oracle
         centralized_oracle_factory.transact(self.tx_data).createCentralizedOracle('QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
         # Run event listener again
-        event_listener()
+        event_listener(self.provider)
         # Do checks
         daemon = Daemon.get_solo()
-        self.assertEquals(daemon.block_number, daemon_factory.block_number+1)
-        self.assertEquals(Block.objects.all().count(), n_blocks+1)
+        self.assertEqual(daemon.block_number, daemon_factory.block_number + 2)
+        self.assertEqual(Block.objects.all().count(), n_blocks + 2)
         self.assertFalse(daemon.listener_lock)

--- a/django_eth_events/tests/test_daemon_model.py
+++ b/django_eth_events/tests/test_daemon_model.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from django.test import TestCase
-from django_eth_events.factories import DaemonFactory
-from django_eth_events.models import Daemon
+
+from ..factories import DaemonFactory
+from ..models import Daemon
 
 
 class TestDaemonModel(TestCase):

--- a/django_eth_events/tests/test_decoder.py
+++ b/django_eth_events/tests/test_decoder.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from django.test import TestCase
-from django_eth_events.decoder import Decoder
 from json import loads
+
+from django.test import TestCase
+
+from ..decoder import Decoder
 
 
 class TestDecoder(TestCase):
@@ -25,23 +26,23 @@ class TestDecoder(TestCase):
 
     def test_add_abis(self):
         self.decoder.add_abi([])
-        self.assertEquals(len(self.decoder.methods), 0)
+        self.assertEqual(len(self.decoder.methods), 0)
         self.decoder.add_abi(self.test_abi)
-        self.assertEquals(len(self.decoder.methods), 5)
+        self.assertEqual(len(self.decoder.methods), 5)
         self.decoder.remove_abi([])
-        self.assertEquals(len(self.decoder.methods), 5)
+        self.assertEqual(len(self.decoder.methods), 5)
         self.decoder.remove_abi(loads('[{"inputs": [{"type": "address", "name": ""}], "constant": true, "name": "isInstantiation", "payable": false, "outputs": [{"type": "bool", "name": ""}], "type": "function"}]'))
-        self.assertEquals(len(self.decoder.methods), 4)
+        self.assertEqual(len(self.decoder.methods), 4)
         self.decoder.remove_abi(self.test_abi)
-        self.assertEquals(len(self.decoder.methods), 0)
+        self.assertEqual(len(self.decoder.methods), 0)
 
     def test_decode_logs(self):
         logs = [
           {
-            u'address' : u'0xa6d9c5f7d4de3cef51ad3b7235d79ccc95114de5',
-            u'data' : u"0x00000000000000000000000065039084cc6f4773291a6ed7dcf5bc3a2e894ff300000000000000000000000017e054b16ca658789c927c854976450adbda7df0",
-            u'topics' : [
-                u'0x4fb057ad4a26ed17a57957fa69c306f11987596069b89521c511fc9a894e6161'
+            'address' : '0xa6d9c5f7d4de3cef51ad3b7235d79ccc95114de5',
+            'data' : u"0x00000000000000000000000065039084cc6f4773291a6ed7dcf5bc3a2e894ff300000000000000000000000017e054b16ca658789c927c854976450adbda7df0",
+            'topics' : [
+                '0x4fb057ad4a26ed17a57957fa69c306f11987596069b89521c511fc9a894e6161'
             ]
           }
         ]
@@ -52,16 +53,16 @@ class TestDecoder(TestCase):
         self.assertListEqual(
             [
                 {
-                    u'address': u'a6d9c5f7d4de3cef51ad3b7235d79ccc95114de5',
-                    u'name': u'ContractInstantiation',
-                    u'params': [
+                    'address': 'a6d9c5f7d4de3cef51ad3b7235d79ccc95114de5',
+                    'name': 'ContractInstantiation',
+                    'params': [
                         {
-                            u'name': u'sender',
-                            u'value': u'65039084cc6f4773291a6ed7dcf5bc3a2e894ff3'
+                            'name': 'sender',
+                            'value': '65039084cc6f4773291a6ed7dcf5bc3a2e894ff3'
                         },
                         {
-                            u'name': u'instantiation',
-                            u'value': u'17e054b16ca658789c927c854976450adbda7df0'
+                            'name': 'instantiation',
+                            'value': '17e054b16ca658789c927c854976450adbda7df0'
                         }
                     ]
                 }

--- a/django_eth_events/utils.py
+++ b/django_eth_events/utils.py
@@ -1,4 +1,5 @@
 from json import JSONEncoder
+
 from eth_utils import to_normalized_address
 
 

--- a/django_eth_events/web3_service.py
+++ b/django_eth_events/web3_service.py
@@ -26,9 +26,11 @@ class Web3Service(object):
     def __new__(cls, provider=None):
         if not Web3Service.instance:
             Web3Service.instance = Web3Service.__Web3Service(provider)
-        elif provider and not isinstance(provider, Web3Service.instance.web3.currentProvider.__class__):
+        elif provider and not isinstance(provider,
+                                         Web3Service.instance.web3.providers[0].__class__):
             Web3Service.instance = Web3Service.__Web3Service(provider)
-        elif not provider and not isinstance(Web3Service.instance.web3.currentProvider, Web3Service.instance.default_provider):
+        elif not provider and not isinstance(Web3Service.instance.web3.providers[0],
+                                             Web3Service.instance.default_provider):
             Web3Service.instance = Web3Service.__Web3Service(provider)
         return Web3Service.instance
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
 celery==4.1.0
-Django==1.11
+Django==2.0.2
 django-authtools==1.6.0
-django-model-utils==2.6.1
+django-model-utils==3.1.1
 django-solo==1.1.3
 ethereum==1.6.1
 eth-abi==0.5.0
 eth-utils==0.7.4
 factory-boy==2.10.0
 kombu==4.1.0
-six==1.11.0
-web3[tester]==3.16.5
+web3==3.16.5

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,7 @@ requirements = [
     "eth-utils==0.7.4",
     "ethereum==1.6.1",
     "kombu==4.1.0",
-    "six==1.11.0",
-    "web3[tester]==3.16.4",
+    "web3==3.16.5",
 ]
 
 setup(


### PR DESCRIPTION
- Rename deprecated functions, like bytes deprecation for abi decode
- Fix event listener provider
- Add Ethereum tester to singleton test
- Change TestRPC for Eth-Tester
- Update Django to v2.0.2 and django-model-utils
- Remove Python2 from Travis build
- Remove six for Python2
- Use relative imports
- Remove old unicode strings