### PR TITLE
Check listener functions exist

### DIFF
--- a/django_eth_events/settings/base.py
+++ b/django_eth_events/settings/base.py
@@ -37,7 +37,7 @@ CELERY_ACCEPT_CONTENT = ['application/json']
 CELERYD_HIJACK_ROOT_LOGGER = False
 CELERYD_PREFETCH_MULTIPLIER = 1
 CELERYD_MAX_TASKS_PER_CHILD = 1000
-CELERY_LOCK_EXPIRE = 60 # 1 minute
+CELERY_LOCK_EXPIRE = 60  # 1 minute
 
 # ------------------------------------------------------------------------------
 # IPFS CONFIGURATION

--- a/django_eth_events/tests/test_celery.py
+++ b/django_eth_events/tests/test_celery.py
@@ -26,7 +26,6 @@ class DummyEventReceiver(AbstractEventReceiver):
 class TestCelery(TestCase):
 
     def setUp(self):
-        os.environ.update({'TESTRPC_GAS_LIMIT': '10000000000'})
         self.web3 = Web3Service(provider=EthereumTesterProvider(EthereumTester())).web3
         self.provider = self.web3.providers[0]
         self.web3.eth.defaultAccount = self.web3.eth.coinbase
@@ -85,6 +84,7 @@ class TestCelery(TestCase):
         event_listener(self.provider)
         # Do checks
         daemon = Daemon.get_solo()
+        self.assertEqual(daemon.status, 'EXECUTING')
         self.assertEqual(daemon.block_number, daemon_factory.block_number + 2)
         self.assertEqual(Block.objects.all().count(), n_blocks + 2)
         self.assertFalse(daemon.listener_lock)

--- a/django_eth_events/tests/test_event_listener_exec.py
+++ b/django_eth_events/tests/test_event_listener_exec.py
@@ -17,7 +17,6 @@ from .utils import (CentralizedOracle, centralized_oracle_abi,
 
 class TestDaemonExec(TestCase):
     def setUp(self):
-        os.environ.update({'TESTRPC_GAS_LIMIT': '10000000000'})
         self.web3 = Web3Service(provider=EthereumTesterProvider(EthereumTester())).web3
         self.provider = self.web3.providers[0]
         self.web3.eth.defaultAccount = self.web3.eth.coinbase

--- a/django_eth_events/tests/test_singleton.py
+++ b/django_eth_events/tests/test_singleton.py
@@ -60,10 +60,12 @@ class TestSingleton(TestCase):
         self.assertNotEqual(listener2, listener3)
 
         # For a different contract we need a different instance of the singleton even if provider is the same
-        contract_map = {'NAME': 'Tester Oracle Factory', 'EVENT_ABI': [],
-                        'EVENT_DATA_RECEIVER': 'django_eth_events.tests.test_celery.DummyEventReceiver',
-                        'ADDRESSES': ['c305c901078781C232A2a521C2aF7980f8385ee9']
-                        }
+        contract_map = [
+            {'NAME': 'Tester Oracle Factory', 'EVENT_ABI': [],
+             'EVENT_DATA_RECEIVER': 'django_eth_events.tests.test_celery.DummyEventReceiver',
+             'ADDRESSES': ['c305c901078781C232A2a521C2aF7980f8385ee9']
+             }
+        ]
         listener4 = EventListener(provider=ipc_provider, contract_map=contract_map)
         self.assertNotEqual(listener3, listener4)
         listener5 = EventListener(provider=ipc_provider, contract_map=contract_map)


### PR DESCRIPTION
- Get classes from strings at first, so we can fail fast
- Make sync faster, because we don't have to find classes in every iteration
- Fix tests
- Remove Testrpc gas limit