### PR TITLE
Make Abstract classes compliant with Python>=3.6, add transaction_has…

### DIFF
--- a/django_eth_events/chainevents.py
+++ b/django_eth_events/chainevents.py
@@ -1,5 +1,5 @@
-from abc import ABCMeta, abstractmethod
-from typing import Optional, List
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional
 
 from .singleton import SingletonABCMeta
 
@@ -14,11 +14,11 @@ class AbstractAddressesGetter(metaclass=SingletonABCMeta):
     def __contains__(self, address: str) -> bool: pass
 
 
-class AbstractEventReceiver(metaclass=ABCMeta):
+class AbstractEventReceiver(ABC):
     """Abstract EventReceiver class."""
 
     @abstractmethod
-    def save(self, decoded_event: dict, block_info: dict) -> Optional[object]:
+    def save(self, decoded_event: Dict, block_info: Dict) -> Optional[object]:
         """
         Let the inheriting EventReceiver save data. The way data is handled is up to the EventReceiver.
         :param decoded_event: See django_eth_events.decoder.Decoder
@@ -30,7 +30,7 @@ class AbstractEventReceiver(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def rollback(self, decoded_event: dict, block_info: dict) -> Optional[object]:
+    def rollback(self, decoded_event: Dict, block_info: Dict) -> Optional[object]:
         """
         Let the inheriting EventReceiver undo saved data. The way data is handled is up to the EventReceiver.
         :param decoded_event: See django_eth_events.decoder.Decoder

--- a/django_eth_events/chainevents.py
+++ b/django_eth_events/chainevents.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 
-from .singleton import SingletonABCMeta
+from .singleton import SingletonABC
 
 
-class AbstractAddressesGetter(metaclass=SingletonABCMeta):
+class AbstractAddressesGetter(SingletonABC):
     """Abstract AddressesGetter class."""
 
     @abstractmethod

--- a/django_eth_events/chainevents.py
+++ b/django_eth_events/chainevents.py
@@ -1,25 +1,41 @@
 from abc import ABCMeta, abstractmethod
+from typing import Optional, List
 
 from .singleton import SingletonABCMeta
 
 
-class AbstractAddressesGetter(object):
+class AbstractAddressesGetter(metaclass=SingletonABCMeta):
     """Abstract AddressesGetter class."""
-    __metaclass__ = SingletonABCMeta
 
     @abstractmethod
-    def get_addresses(self): pass
+    def get_addresses(self) -> List: pass
 
     @abstractmethod
-    def __contains__(self, address): pass
+    def __contains__(self, address: str) -> bool: pass
 
 
-class AbstractEventReceiver(object):
+class AbstractEventReceiver(metaclass=ABCMeta):
     """Abstract EventReceiver class."""
-    __metaclass__ = ABCMeta
 
     @abstractmethod
-    def save(self, decoded_event, block_info): pass
+    def save(self, decoded_event: dict, block_info: dict) -> Optional[object]:
+        """
+        Let the inheriting EventReceiver save data. The way data is handled is up to the EventReceiver.
+        :param decoded_event: See django_eth_events.decoder.Decoder
+        :type decoded_event: dict
+        :param block_info: Contains data representing a Block. See https://web3py.readthedocs.io/en/stable/examples.html#looking-up-blocks
+        :type block_info: dict
+        :return: the updated instance or None
+        """
+        pass
 
     @abstractmethod
-    def rollback(self, decoded_event, block_info): pass
+    def rollback(self, decoded_event: dict, block_info: dict) -> Optional[object]:
+        """
+        Let the inheriting EventReceiver undo saved data. The way data is handled is up to the EventReceiver.
+        :param decoded_event: See django_eth_events.decoder.Decoder
+        :type decoded_event: dict
+        :param block_info: Contains data representing a Block. See https://web3py.readthedocs.io/en/stable/examples.html#looking-up-blocks
+        :type block_info: dict
+        """
+        pass

--- a/django_eth_events/decoder.py
+++ b/django_eth_events/decoder.py
@@ -125,20 +125,38 @@ class Decoder(Singleton):
         decoded_event = {
             'params': decoded_params,
             'name': method['name'],
-            'address': self.decode_address(log['address'])
+            'address': self.decode_address(log['address']),
+            'transaction_hash': self.decode_transaction(log['transactionHash'])
         }
 
         return decoded_event
 
     @staticmethod
     def decode_address(address):
+        if not address:
+            raise ValueError
+
         if isinstance(address, bytes):
             address = address.hex()
+
         # Address length must be 40 (42 with 0x), but usually it's packed on 32 bits (length of 66 with 0x)
         if len(address) == 66:
             address = address[26:]
 
         return normalize_address_without_0x(address)
+
+    @staticmethod
+    def decode_transaction(tx_hash):
+        if not tx_hash:
+            raise ValueError
+
+        if isinstance(tx_hash, (bytes, HexBytes)):
+            tx_hash = tx_hash.hex()
+
+        if len(tx_hash) < 64:
+            raise ValueError
+
+        return tx_hash
 
     def decode_logs(self, logs):
         """

--- a/django_eth_events/decoder.py
+++ b/django_eth_events/decoder.py
@@ -150,8 +150,12 @@ class Decoder(Singleton):
         if not tx_hash:
             raise ValueError
 
-        if isinstance(tx_hash, (bytes, HexBytes)):
+        if isinstance(tx_hash, bytes):
             tx_hash = tx_hash.hex()
+
+        tx_hash = tx_hash.strip()  # Trim spaces
+        if tx_hash.startswith('0x'):  # Remove 0x prefix
+            tx_hash = tx_hash[2:]
 
         if len(tx_hash) < 64:
             raise ValueError

--- a/django_eth_events/singleton.py
+++ b/django_eth_events/singleton.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta
+from abc import ABC
 
 
 class Singleton(object):
@@ -13,7 +13,7 @@ class Singleton(object):
         return cls._instance
 
 
-class SingletonABCMeta(ABCMeta):
+class SingletonABC(ABC):
     _instances = {}
 
     def __call__(cls, *args, **kwargs):

--- a/django_eth_events/tests/test_chainevents.py
+++ b/django_eth_events/tests/test_chainevents.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from ..chainevents import AbstractEventReceiver, AbstractAddressesGetter
+
+
+class EventReceiverImpl(AbstractEventReceiver):
+    pass
+
+
+class AddressGetterImpl(AbstractAddressesGetter):
+    pass
+
+
+class TestAbstractClasses(TestCase):
+
+    def test_abstract_class_detected(self):
+        # Make sure abstract classes gets detected as abstracts. This to prevent
+        # not desired behaviour when updating Python version.
+        with self.assertRaises(TypeError):
+            EventReceiverImpl()
+
+        with self.assertRaises(TypeError):
+            AddressGetterImpl()

--- a/django_eth_events/tests/test_decoder.py
+++ b/django_eth_events/tests/test_decoder.py
@@ -44,6 +44,7 @@ class TestDecoder(TestCase):
           {
             'address': '0xa6d9c5f7d4de3cef51ad3b7235d79ccc95114de5',
             'data': u"0x00000000000000000000000065039084cc6f4773291a6ed7dcf5bc3a2e894ff300000000000000000000000017e054b16ca658789c927c854976450adbda7df0",
+            'transactionHash': '0x54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa',
             'topics': [
                 HexBytes('0x4fb057ad4a26ed17a57957fa69c306f11987596069b89521c511fc9a894e6161')
             ]
@@ -58,6 +59,7 @@ class TestDecoder(TestCase):
                 {
                     'address': 'a6d9c5f7d4de3cef51ad3b7235d79ccc95114de5',
                     'name': 'ContractInstantiation',
+                    'transaction_hash': logs[0]['transactionHash'],
                     'params': [
                         {
                             'name': 'sender',
@@ -72,3 +74,50 @@ class TestDecoder(TestCase):
             ],
             decoded
         )
+
+    def test_validation_errors(self):
+        self.decoder.add_abi(self.test_abi)
+        # Create base not decoded log, which contains camelcase `transactionHash`
+        base_log = {
+            'address': '0xa6d9c5f7d4de3cef51ad3b7235d79ccc95114de5',
+            'transactionHash': '0x54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa',
+            'data': u"0x00000000000000000000000065039084cc6f4773291a6ed7dcf5bc3a2e894ff300000000000000000000000017e054b16ca658789c927c854976450adbda7df0",
+            'topics': [
+                HexBytes('0x4fb057ad4a26ed17a57957fa69c306f11987596069b89521c511fc9a894e6161')
+            ]
+        }
+
+        logs_with_invalid_address = [
+            {
+                **base_log,
+                'address': '0x'
+            }
+        ]
+        self.assertRaises(ValueError, self.decoder.decode_logs, logs_with_invalid_address)
+
+        logs_with_invalid_address = [
+            {
+                **base_log,
+                'address': None
+            }
+        ]
+        self.assertRaises(ValueError, self.decoder.decode_logs, logs_with_invalid_address)
+
+        logs_with_valid_address = [base_log]
+        self.assertIsNotNone(self.decoder.decode_logs(logs_with_valid_address))
+
+        logs_with_invalid_tx_hash = [
+            {
+                **base_log,
+                'transactionHash': '0x'
+            }
+        ]
+        self.assertRaises(ValueError, self.decoder.decode_logs, logs_with_invalid_tx_hash)
+
+        logs_with_invalid_tx_hash = [
+            {
+                **base_log,
+                'transactionHash': None
+            }
+        ]
+        self.assertRaises(ValueError, self.decoder.decode_logs, logs_with_invalid_tx_hash)

--- a/django_eth_events/tests/test_decoder.py
+++ b/django_eth_events/tests/test_decoder.py
@@ -59,7 +59,7 @@ class TestDecoder(TestCase):
                 {
                     'address': 'a6d9c5f7d4de3cef51ad3b7235d79ccc95114de5',
                     'name': 'ContractInstantiation',
-                    'transaction_hash': logs[0]['transactionHash'],
+                    'transaction_hash': logs[0]['transactionHash'][2:], # without `0x`
                     'params': [
                         {
                             'name': 'sender',
@@ -121,3 +121,43 @@ class TestDecoder(TestCase):
             }
         ]
         self.assertRaises(ValueError, self.decoder.decode_logs, logs_with_invalid_tx_hash)
+
+        logs_with_valid_tx_hash = [
+            {
+                **base_log,
+                'transactionHash': HexBytes('0x54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa')
+            }
+        ]
+        self.assertIsNotNone(self.decoder.decode_logs(logs_with_valid_tx_hash))
+
+        logs_with_valid_tx_hash = [
+            {
+                **base_log,
+                'transactionHash': HexBytes('54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa')
+            }
+        ]
+        self.assertIsNotNone(self.decoder.decode_logs(logs_with_valid_tx_hash))
+
+        logs_with_valid_tx_hash = [
+            {
+                **base_log,
+                'transactionHash': HexBytes('0x54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa').hex()
+            }
+        ]
+        self.assertIsNotNone(self.decoder.decode_logs(logs_with_valid_tx_hash))
+
+        logs_with_valid_tx_hash = [
+            {
+                **base_log,
+                'transactionHash': bytes(HexBytes('0x54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa')).hex()
+            }
+        ]
+        self.assertIsNotNone(self.decoder.decode_logs(logs_with_valid_tx_hash))
+
+        logs_with_valid_tx_hash = [
+            {
+                **base_log,
+                'transactionHash': bytes(HexBytes('54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa')).hex()
+            }
+        ]
+        self.assertIsNotNone(self.decoder.decode_logs(logs_with_valid_tx_hash))

--- a/django_eth_events/tests/test_decoder.py
+++ b/django_eth_events/tests/test_decoder.py
@@ -75,6 +75,56 @@ class TestDecoder(TestCase):
             decoded
         )
 
+    def test_decode_transaction_hash(self):
+        self.decoder.add_abi(self.test_abi)
+
+        base_logs = [
+          {
+            'address': '0xa6d9c5f7d4de3cef51ad3b7235d79ccc95114de5',
+            'data': u"0x00000000000000000000000065039084cc6f4773291a6ed7dcf5bc3a2e894ff300000000000000000000000017e054b16ca658789c927c854976450adbda7df0",
+            'transactionHash': '0x54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa',
+            'topics': [
+                HexBytes('0x4fb057ad4a26ed17a57957fa69c306f11987596069b89521c511fc9a894e6161')
+            ]
+          }
+        ]
+
+        logs_with_hex_tx_hash = [{
+            **base_logs[0],
+            'transactionHash': HexBytes('0x54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa')
+        }]
+        decoded = self.decoder.decode_logs(logs_with_hex_tx_hash)
+        # Test decoded transaction_hash is without `0x` prefix
+        self.assertEquals(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'].hex()[2:])
+        self.assertFalse(decoded[0]['transaction_hash'].startswith('0x'))
+
+        logs_with_hex_tx_hash = [{
+            **base_logs[0],
+            'transactionHash': bytes(HexBytes('54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa')).hex()
+        }]
+        decoded = self.decoder.decode_logs(logs_with_hex_tx_hash)
+        # Test decoded transaction_hash is without `0x` prefix
+        self.assertEquals(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'])
+        self.assertFalse(decoded[0]['transaction_hash'].startswith('0x'))
+
+        logs_with_hex_tx_hash = [{
+            **base_logs[0],
+            'transactionHash': bytes(HexBytes('54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa'))
+        }]
+        decoded = self.decoder.decode_logs(logs_with_hex_tx_hash)
+        # Test decoded transaction_hash is without `0x` prefix
+        self.assertEquals(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'].hex())
+        self.assertFalse(decoded[0]['transaction_hash'].startswith('0x'))
+
+        logs_with_hex_tx_hash = [{
+            **base_logs[0],
+            'transactionHash': bytes(HexBytes('0x54041b3ce0976ee17212100f42b3793fa4ee5f869a6d107249a75caa5fc1b8aa'))
+        }]
+        decoded = self.decoder.decode_logs(logs_with_hex_tx_hash)
+        # Test decoded transaction_hash is without `0x` prefix
+        self.assertEquals(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'].hex())
+        self.assertFalse(decoded[0]['transaction_hash'].startswith('0x'))
+
     def test_validation_errors(self):
         self.decoder.add_abi(self.test_abi)
         # Create base not decoded log, which contains camelcase `transactionHash`

--- a/django_eth_events/tests/test_decoder.py
+++ b/django_eth_events/tests/test_decoder.py
@@ -95,7 +95,7 @@ class TestDecoder(TestCase):
         }]
         decoded = self.decoder.decode_logs(logs_with_hex_tx_hash)
         # Test decoded transaction_hash is without `0x` prefix
-        self.assertEquals(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'].hex()[2:])
+        self.assertEqual(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'].hex()[2:])
         self.assertFalse(decoded[0]['transaction_hash'].startswith('0x'))
 
         logs_with_hex_tx_hash = [{
@@ -104,7 +104,7 @@ class TestDecoder(TestCase):
         }]
         decoded = self.decoder.decode_logs(logs_with_hex_tx_hash)
         # Test decoded transaction_hash is without `0x` prefix
-        self.assertEquals(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'])
+        self.assertEqual(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'])
         self.assertFalse(decoded[0]['transaction_hash'].startswith('0x'))
 
         logs_with_hex_tx_hash = [{
@@ -113,7 +113,7 @@ class TestDecoder(TestCase):
         }]
         decoded = self.decoder.decode_logs(logs_with_hex_tx_hash)
         # Test decoded transaction_hash is without `0x` prefix
-        self.assertEquals(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'].hex())
+        self.assertEqual(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'].hex())
         self.assertFalse(decoded[0]['transaction_hash'].startswith('0x'))
 
         logs_with_hex_tx_hash = [{
@@ -122,7 +122,7 @@ class TestDecoder(TestCase):
         }]
         decoded = self.decoder.decode_logs(logs_with_hex_tx_hash)
         # Test decoded transaction_hash is without `0x` prefix
-        self.assertEquals(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'].hex())
+        self.assertEqual(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'].hex())
         self.assertFalse(decoded[0]['transaction_hash'].startswith('0x'))
 
     def test_validation_errors(self):
@@ -160,6 +160,14 @@ class TestDecoder(TestCase):
             {
                 **base_log,
                 'transactionHash': '0x'
+            }
+        ]
+        self.assertRaises(ValueError, self.decoder.decode_logs, logs_with_invalid_tx_hash)
+
+        logs_with_invalid_tx_hash = [
+            {
+                **base_log,
+                'transactionHash': '0x0123456789'
             }
         ]
         self.assertRaises(ValueError, self.decoder.decode_logs, logs_with_invalid_tx_hash)

--- a/django_eth_events/tests/test_event_listener_functions.py
+++ b/django_eth_events/tests/test_event_listener_functions.py
@@ -104,7 +104,7 @@ class TestDaemon(TestCase):
             {
                 'address': normalize_address_without_0x(factory_address),
                 'name': 'OwnersInit',
-                'transaction_hash': logs[0]['transactionHash'].hex(),
+                'transaction_hash': logs[0]['transactionHash'].hex()[2:],
                 'params': [
                     {
                         'name': 'owners',
@@ -120,7 +120,7 @@ class TestDaemon(TestCase):
             {
                 'address': normalize_address_without_0x(factory_address),
                 'name': 'ContractInstantiation',
-                'transaction_hash': logs[1]['transactionHash'].hex(),
+                'transaction_hash': logs[1]['transactionHash'].hex()[2:],
                 'params': [
                     {
                         'name': 'sender',

--- a/django_eth_events/tests/test_event_listener_functions.py
+++ b/django_eth_events/tests/test_event_listener_functions.py
@@ -104,6 +104,7 @@ class TestDaemon(TestCase):
             {
                 'address': normalize_address_without_0x(factory_address),
                 'name': 'OwnersInit',
+                'transaction_hash': logs[0]['transactionHash'].hex(),
                 'params': [
                     {
                         'name': 'owners',
@@ -119,6 +120,7 @@ class TestDaemon(TestCase):
             {
                 'address': normalize_address_without_0x(factory_address),
                 'name': 'ContractInstantiation',
+                'transaction_hash': logs[1]['transactionHash'].hex(),
                 'params': [
                     {
                         'name': 'sender',

--- a/django_eth_events/utils.py
+++ b/django_eth_events/utils.py
@@ -1,5 +1,6 @@
 import errno
 
+from hexbytes import HexBytes
 from json import JSONEncoder
 from requests.exceptions import RequestException
 from urllib3.exceptions import HTTPError
@@ -39,8 +40,11 @@ def normalize_address_without_0x(address) -> str:
 
 
 class JsonBytesEncoder(JSONEncoder):
-        def default(self, obj):
-            if isinstance(obj, bytes):
-                return obj.decode('ascii')
-            # Let the base class default method raise the TypeError
-            return JSONEncoder.default(self, obj)
+    def default(self, obj):
+        if isinstance(obj, HexBytes):
+            return obj.hex()
+        if isinstance(obj, bytes):
+            return obj.decode('ascii')
+
+        # Let the base class default method raise the TypeError
+        return JSONEncoder.default(self, obj)

--- a/django_eth_events/utils.py
+++ b/django_eth_events/utils.py
@@ -41,10 +41,8 @@ def normalize_address_without_0x(address) -> str:
 
 class JsonBytesEncoder(JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, HexBytes):
-            return obj.hex()
         if isinstance(obj, bytes):
-            return obj.decode('ascii')
+            return '0x' + obj.hex()
 
         # Let the base class default method raise the TypeError
         return JSONEncoder.default(self, obj)


### PR DESCRIPTION
- Add `transaction_hash` property to each decoded log
- Update abstract classes to make use of `ABCMeta` metaclass correctly