### PR TITLE
Fix how JsonBytesEncoder encodes primitive bytes

### DIFF
--- a/django_eth_events/tests/test_decoder.py
+++ b/django_eth_events/tests/test_decoder.py
@@ -124,6 +124,7 @@ class TestDecoder(TestCase):
         # Test decoded transaction_hash is without `0x` prefix
         self.assertEqual(decoded[0]['transaction_hash'], logs_with_hex_tx_hash[0]['transactionHash'].hex())
         self.assertFalse(decoded[0]['transaction_hash'].startswith('0x'))
+        self.assertIsInstance(decoded[0]['transaction_hash'], str)
 
     def test_validation_errors(self):
         self.decoder.add_abi(self.test_abi)

--- a/django_eth_events/tests/test_utils.py
+++ b/django_eth_events/tests/test_utils.py
@@ -2,12 +2,13 @@ import errno
 from django.test import TestCase
 from hexbytes import HexBytes
 from urllib3.exceptions import HTTPError, LocationValueError, PoolError
+from json import dumps, loads
 
-from ..utils import normalize_address_without_0x, remove_0x_head, is_network_error
+from ..utils import normalize_address_without_0x, remove_0x_head, is_network_error, JsonBytesEncoder
 from ..exceptions import Web3ConnectionException
 
 
-class TestSingleton(TestCase):
+class TestUtils(TestCase):
 
     def test_remove_0x_head(self):
         self.assertEqual('b58d5491D17ebF46E9DB7F18CeA7C556AE80d53B',
@@ -65,3 +66,24 @@ class TestSingleton(TestCase):
 
         setattr(w3_conn_error, 'errno', errno.EPERM)
         self.assertFalse(is_network_error(w3_conn_error))
+
+    def test_json_encoder(self):
+        ipfs_hash_string = 'Qme4GBhwNJharbu83iNEsd5WnUhQYM1rBAgCgsSuFMdjcS'
+        ipfs_hash_bytes = ipfs_hash_string.encode()  # b'...'
+
+        json = {'ipfs_hash': ipfs_hash_bytes}
+        # Simulate string encoding and convert back to dict
+        encoded_json = loads(dumps(json, cls=JsonBytesEncoder))
+        self.assertEqual(ipfs_hash_bytes.decode(), encoded_json['ipfs_hash'])
+
+        json = {'ipfs_hash': ipfs_hash_string}
+        # Simulate string encoding and convert back to dict
+        encoded_json = loads(dumps(json, cls=JsonBytesEncoder))
+        self.assertEqual(ipfs_hash_string, encoded_json['ipfs_hash'])
+
+        hex_bytes_address = HexBytes('b58d5491d17ebf46e9db7f18cea7c556ae80d53B')
+        json = {'address': hex_bytes_address}
+        encoded_json = loads(dumps(json, cls=JsonBytesEncoder))
+        self.assertEqual(hex_bytes_address.hex(), encoded_json['address'])
+
+

--- a/django_eth_events/tests/test_utils.py
+++ b/django_eth_events/tests/test_utils.py
@@ -68,6 +68,7 @@ class TestUtils(TestCase):
         self.assertFalse(is_network_error(w3_conn_error))
 
     def test_json_encoder(self):
+        base_address = 'b58d5491d17ebf46e9db7f18cea7c556ae80d53B'
         ipfs_hash_string = 'Qme4GBhwNJharbu83iNEsd5WnUhQYM1rBAgCgsSuFMdjcS'
         ipfs_hash_bytes = ipfs_hash_string.encode()  # b'...'
 
@@ -81,9 +82,14 @@ class TestUtils(TestCase):
         encoded_json = loads(dumps(json, cls=JsonBytesEncoder))
         self.assertEqual(ipfs_hash_string, encoded_json['ipfs_hash'])
 
-        hex_bytes_address = HexBytes('b58d5491d17ebf46e9db7f18cea7c556ae80d53B')
+        hex_bytes_address = HexBytes(base_address)
         json = {'address': hex_bytes_address}
         encoded_json = loads(dumps(json, cls=JsonBytesEncoder))
-        self.assertEqual(hex_bytes_address.hex(), encoded_json['address'])
+        self.assertEqual('0x' + hex_bytes_address.hex(), encoded_json['address'])
+
+        bytes_address = bytes.fromhex(base_address)
+        json = {'address': bytes_address}
+        encoded_json = loads(dumps(json, cls=JsonBytesEncoder))
+        self.assertEqual('0x' + bytes_address.hex(), encoded_json['address'])
 
 

--- a/django_eth_events/tests/test_utils.py
+++ b/django_eth_events/tests/test_utils.py
@@ -85,7 +85,7 @@ class TestUtils(TestCase):
         hex_bytes_address = HexBytes(base_address)
         json = {'address': hex_bytes_address}
         encoded_json = loads(dumps(json, cls=JsonBytesEncoder))
-        self.assertEqual('0x' + hex_bytes_address.hex(), encoded_json['address'])
+        self.assertEqual(hex_bytes_address.hex(), encoded_json['address'])
 
         bytes_address = bytes.fromhex(base_address)
         json = {'address': bytes_address}

--- a/django_eth_events/utils.py
+++ b/django_eth_events/utils.py
@@ -45,7 +45,7 @@ class JsonBytesEncoder(JSONEncoder):
             try:
                 return obj.decode()
             except UnicodeDecodeError:
-                return '0x' + obj.hex()
+                return HexBytes(obj).hex()
 
         # Let the base class default method raise the TypeError
         return super().default(self, obj)

--- a/django_eth_events/utils.py
+++ b/django_eth_events/utils.py
@@ -41,8 +41,10 @@ def normalize_address_without_0x(address) -> str:
 
 class JsonBytesEncoder(JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, bytes):
-            return '0x' + obj.hex()
+        if isinstance(obj, HexBytes):
+            return obj.hex()
+        elif isinstance(obj, bytes):
+            return obj.decode()
 
         # Let the base class default method raise the TypeError
         return JSONEncoder.default(self, obj)

--- a/django_eth_events/utils.py
+++ b/django_eth_events/utils.py
@@ -41,10 +41,11 @@ def normalize_address_without_0x(address) -> str:
 
 class JsonBytesEncoder(JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, HexBytes):
-            return obj.hex()
-        elif isinstance(obj, bytes):
-            return obj.decode()
+        if isinstance(obj, bytes):
+            try:
+                return obj.decode()
+            except UnicodeDecodeError:
+                return '0x' + obj.hex()
 
         # Let the base class default method raise the TypeError
-        return JSONEncoder.default(self, obj)
+        return super().default(self, obj)


### PR DESCRIPTION
JsonBytesEncoder was encoding primitive bytes wrongly, as for example:
`b'Qme4GBhwNJharbu83iNEsd5WnUhQYM1rBAgCgsSuFMdjcS'` got encoded as `516d6534474268774e4a68617262753833694e45736435576e556851594d31724241674367735375464d646a6353` instead of `Qme4GBhwNJharbu83iNEsd5WnUhQYM1rBAgCgsSuFMdjcS` .
